### PR TITLE
Blacklist for Window Controls

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -35,6 +35,6 @@
   "WindowControls.TaskbarColorHint": "Color of the Taskbar when 'Top Taskbar' Organized Mode is enabled",
 
   "WindowControls.AppBlacklistName": "App Blacklist",
-  "WindowControls.AppBlacklistHint": "Apps that Window Controls should ignore. You need to know the app's ID or baseApplication via digging in code. Separate with comas."
+  "WindowControls.AppBlacklistHint": "Apps that Window Controls should ignore. You need to know the app's case sensitive name. Separate with comas."
 
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -32,6 +32,11 @@
   "WindowControls.MaximizeButtonHint": "Add a maximize button on resizeable windows. May not work well with all systems",
 
   "WindowControls.TaskbarColorName": "Taskbar Color",
-  "WindowControls.TaskbarColorHint": "Color of the Taskbar when 'Top Taskbar' Organized Mode is enabled"
+  "WindowControls.TaskbarColorHint": "Color of the Taskbar when 'Top Taskbar' Organized Mode is enabled",
+
+  "WindowControls.AppBlacklistName": "App Blacklist",
+  "WindowControls.AppBlacklistHint": "Apps that Window Controls should ignore. You need to know the app's ID or baseApplication via digging in code. Separate with comas.", 
+  "WindowControls.AppBlacklistHint2": "appId,appId,appId", 
+  "WindowControls.AppBlacklistError": "Incorrectly configured blacklist. Should be as follows: appId,appId,appId"
 
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -35,8 +35,6 @@
   "WindowControls.TaskbarColorHint": "Color of the Taskbar when 'Top Taskbar' Organized Mode is enabled",
 
   "WindowControls.AppBlacklistName": "App Blacklist",
-  "WindowControls.AppBlacklistHint": "Apps that Window Controls should ignore. You need to know the app's ID or baseApplication via digging in code. Separate with comas.", 
-  "WindowControls.AppBlacklistHint2": "appId,appId,appId", 
-  "WindowControls.AppBlacklistError": "Incorrectly configured blacklist. Should be as follows: appId,appId,appId"
+  "WindowControls.AppBlacklistHint": "Apps that Window Controls should ignore. You need to know the app's ID or baseApplication via digging in code. Separate with comas."
 
 }

--- a/windowcontrols.js
+++ b/windowcontrols.js
@@ -11,10 +11,6 @@ class WindowControls {
   static cssTopBarPersistentLeftStart = -5;
   static cssBottomBarLeftStart = 250;
 
-  static defaultBlacklist = [
-    "always-hp"
-  ];
-
   static getTaskbarTop = () => 2;
   static getTaskbarBot = () => $("#board").height() - 40;
 
@@ -290,6 +286,14 @@ class WindowControls {
   }
 
   static setMinimizedStyle(app) {
+
+    try {
+      const blacklist = game.settings.get('window-controls', 'appBlacklist');
+      if (blacklist.split(",").find(bId => bId.trim() === app.constructor.name) != null) return;
+    }
+    catch (e) {
+      console.warn("Blacklist formatted incorrectly.")
+    }
     if (!app?.element) return;
     app.element.find(".window-header > h4").text(WindowControls.curateTitle(app.title));
     app.element.find(".minimize").empty();
@@ -298,10 +302,10 @@ class WindowControls {
   }
 
   static setRestoredStyle(app) {
-    const appId = app.options.baseApplication ?? app.options.id;
+
     try {
       const blacklist = game.settings.get('window-controls', 'appBlacklist');
-      if (blacklist.split(",").find(bId => bId.trim() === appId) != null) return;
+      if (blacklist.split(",").find(bId => bId.trim() === app.constructor.name) != null) return;
     }
     catch (e) {
       console.warn("Blacklist formatted incorrectly.")
@@ -574,6 +578,10 @@ class WindowControls {
       }
     });
 
+
+    const defaultBlacklist = [
+      "AlwaysHP"
+    ];
     game.settings.register('window-controls', 'appBlacklist', {
       name: game.i18n.localize("WindowControls.AppBlacklistName"),
       hint: game.i18n.localize("WindowControls.AppBlacklistHint"),

--- a/windowcontrols.js
+++ b/windowcontrols.js
@@ -11,7 +11,7 @@ class WindowControls {
   static cssTopBarPersistentLeftStart = -5;
   static cssBottomBarLeftStart = 250;
 
-  static defaultBlacklist =  [
+  static defaultBlacklist = [
     "always-hp"
   ];
 
@@ -299,17 +299,20 @@ class WindowControls {
 
   static setRestoredStyle(app) {
     const appId = app.options.baseApplication ?? app.options.id;
-    const blacklist = game.settings.get('window-controls', 'appBlacklist');
-    if (blacklist.split(",").find(bId => bId.trim() === appId) != null) return;
-    else {
-      app.element.find(".window-header > h4").text(WindowControls.uncurateTitle(app.title));
-      app.element.find(".minimize").empty();
-      app.element.find(".minimize").append(`<i class="far fa-window-minimize"></i>`);
-      if (app._pinned === true) {
-        app.element.find(".entry-image").hide();
-        app.element.find(".entry-text").hide();
-        app.element.find(".close").hide();
-      }
+    try {
+      const blacklist = game.settings.get('window-controls', 'appBlacklist');
+      if (blacklist.split(",").find(bId => bId.trim() === appId) != null) return;
+    }
+    catch (e) {
+      console.warn("Blacklist formatted incorrectly.")
+    }
+    app.element.find(".window-header > h4").text(WindowControls.uncurateTitle(app.title));
+    app.element.find(".minimize").empty();
+    app.element.find(".minimize").append(`<i class="far fa-window-minimize"></i>`);
+    if (app._pinned === true) {
+      app.element.find(".entry-image").hide();
+      app.element.find(".entry-text").hide();
+      app.element.find(".close").hide();
     }
   }
 

--- a/windowcontrols.js
+++ b/windowcontrols.js
@@ -11,6 +11,10 @@ class WindowControls {
   static cssTopBarPersistentLeftStart = -5;
   static cssBottomBarLeftStart = 250;
 
+  static defaultBlacklist =  [
+    "always-hp"
+  ];
+
   static getTaskbarTop = () => 2;
   static getTaskbarBot = () => $("#board").height() - 40;
 
@@ -294,13 +298,18 @@ class WindowControls {
   }
 
   static setRestoredStyle(app) {
-    app.element.find(".window-header > h4").text(WindowControls.uncurateTitle(app.title));
-    app.element.find(".minimize").empty();
-    app.element.find(".minimize").append(`<i class="far fa-window-minimize"></i>`);
-    if (app._pinned === true) {
-      app.element.find(".entry-image").hide();
-      app.element.find(".entry-text").hide();
-      app.element.find(".close").hide();
+    const appId = app.options.baseApplication ?? app.options.id;
+    const blacklist = game.settings.get('window-controls', 'appBlacklist');
+    if (blacklist.split(",").find(bId => bId.trim() === appId) != null) return;
+    else {
+      app.element.find(".window-header > h4").text(WindowControls.uncurateTitle(app.title));
+      app.element.find(".minimize").empty();
+      app.element.find(".minimize").append(`<i class="far fa-window-minimize"></i>`);
+      if (app._pinned === true) {
+        app.element.find(".entry-image").hide();
+        app.element.find(".entry-text").hide();
+        app.element.find(".close").hide();
+      }
     }
   }
 
@@ -560,6 +569,19 @@ class WindowControls {
         const rootStyle = document.querySelector(':root').style;
         rootStyle.setProperty('--taskbarcolor', newValue);
       }
+    });
+
+    game.settings.register('window-controls', 'appBlacklist', {
+      name: game.i18n.localize("WindowControls.AppBlacklistName"),
+      hint: game.i18n.localize("WindowControls.AppBlacklistHint"),
+      scope: 'world',
+      config: true,
+      requiresReload: true,
+      restricted: true,
+      type: new foundry.data.fields.StringField({
+        initial: defaultBlacklist.join(",")
+      }),
+      default: defaultBlacklist.join(",")
     });
   }
 


### PR DESCRIPTION
This isn't a good fix per say, it requires users to have a certain level of technical knowledge, but I put in a blacklist to avoid window-controls from interfering with certain modules. 

Perhaps it could be improved by having the settings option be a dropdown list of all active module ids to select from? The selections could go into an array and be rendered as chips, that you could click on to remove. It would remove user error. But that's beyond what I know how to implement in foundry right now.

Solving my own bug (and probably others) :  #48 